### PR TITLE
Fix broken wave effect on disabled <button/>

### DIFF
--- a/js/waves.js
+++ b/js/waves.js
@@ -270,12 +270,20 @@
     }
 
     /**
+     * Test if wave effect is applicable on given element
+     */
+    function canWave(element) {
+        return element !== null && 
+            !(element.tagName === 'BUTTON' && element.hasAttribute('disabled'));
+    }
+    
+    /**
      * Bubble the click and show effect if .waves-effect elem was found
      */
     function showEffect(e) {
         var element = getWavesEffectElement(e);
 
-        if (element !== null) {
+        if (canWave(element)) {
             Effect.show(e, element);
 
             if ('ontouchstart' in window) {


### PR DESCRIPTION
In a project of mine, I had to use a button element instead of an anchor in order to have the disabled attribute fully working (e.g. avoid a click to be fired) with no additional code. 

I found out that disabled buttons don't fire events, so, when the time comes to remove the wave effect, the mouseup/mouseleave event inside the showEffect function are not fired, and no Effect.hide is called.

Basically, lot of Effect.show are fired, but no Effect.hide are, so what you get is a lot of overlapping layers over the button (many as the number of clicks on the button) that are never removed.

The fix is basically a test to avoid the Effect.show to be fired if the element is a button with a disabled attribute set (is somehow consistent to avoid a UI feedback on a disabled button).

There will be a better solution, but at least you are aware of the issue.